### PR TITLE
Update multi file manager with latest from damiengkit

### DIFF
--- a/Templates/L2ST4.ttinclude
+++ b/Templates/L2ST4.ttinclude
@@ -702,15 +702,16 @@ class Manager {
 	private class Block {
 		public String Name;
 		public int Start, Length;
+		public bool IncludeInDefault;
 	}
 
 	private Block currentBlock;
-	private List<Block> files = new List<Block>();
-	private Block footer = new Block();
-	private Block header = new Block();
-	private ITextTemplatingEngineHost host;
-	private StringBuilder template;
-	protected List<String> generatedFileNames = new List<String>();
+	private readonly List<Block> files = new List<Block>();
+	private readonly Block footer = new Block();
+	private readonly Block header = new Block();
+	private readonly ITextTemplatingEngineHost host;
+	private readonly StringBuilder template;
+	protected readonly List<String> generatedFileNames = new List<String>();
 
 	public static Manager Create(ITextTemplatingEngineHost host, StringBuilder template) {
 		return (host is IServiceProvider) ? new VSManager(host, template) : new Manager(host, template);
@@ -722,12 +723,14 @@ class Manager {
 		CurrentBlock = new Block { Name = name };
 	}
 
-	public void StartFooter() {
+	public void StartFooter(bool includeInDefault = true) {
 		CurrentBlock = footer;
+		footer.IncludeInDefault = includeInDefault;
 	}
 
-	public void StartHeader() {
+	public void StartHeader(bool includeInDefault = true) {
 		CurrentBlock = header;
+		header.IncludeInDefault = includeInDefault;
 	}
 
 	public void EndBlock() {
@@ -739,13 +742,15 @@ class Manager {
 		currentBlock = null;
 	}
 
-	public virtual void Process(Boolean split) {
+	public virtual void Process(bool split, bool sync = true) {
 		if (split) {
 			EndBlock();
 			String headerText = template.ToString(header.Start, header.Length);
 			String footerText = template.ToString(footer.Start, footer.Length);
 			String outputPath = Path.GetDirectoryName(host.TemplateFile);
 			files.Reverse();
+			if (!footer.IncludeInDefault)
+				template.Remove(footer.Start, footer.Length);
 			foreach(Block block in files) {
 				String fileName = Path.Combine(outputPath, block.Name);
 				String content = headerText + template.ToString(block.Start, block.Length) + footerText;
@@ -753,6 +758,8 @@ class Manager {
 				CreateFile(fileName, content);
 				template.Remove(block.Start, block.Length);
 			}
+			if (!header.IncludeInDefault)
+				template.Remove(header.Start, header.Length);
 		}
 	}
 
@@ -769,7 +776,7 @@ class Manager {
 		get { return null; }
 	}
 
-	protected Boolean IsFileContentDifferent(String fileName, String newContent) {
+	protected bool IsFileContentDifferent(String fileName, String newContent) {
 		return !(File.Exists(fileName) && File.ReadAllText(fileName) == newContent);
 	}
 
@@ -790,10 +797,10 @@ class Manager {
 	}
 
 	private class VSManager: Manager {
-		private EnvDTE.ProjectItem templateProjectItem;
-		private EnvDTE.DTE dte;
-		private Action<String> checkOutAction;
-		private Action<IEnumerable<String>> projectSyncAction;
+		private readonly EnvDTE.ProjectItem templateProjectItem;
+		private readonly EnvDTE.DTE dte;
+		private readonly Action<String> checkOutAction;
+		private readonly Action<List<String>> projectSyncAction;
 
 		public override String DefaultProjectNamespace {
 			get {
@@ -801,15 +808,16 @@ class Manager {
 			}
 		}
 
-		public override String GetCustomToolNamespace(String fileName) {
+		public override String GetCustomToolNamespace(string fileName) {
 			return dte.Solution.FindProjectItem(fileName).Properties.Item("CustomToolNamespace").Value.ToString();
 		}
 
-		public override void Process(Boolean split) {
+		public override void Process(bool split, bool sync) {
 			if (templateProjectItem.ProjectItems == null)
 				return;
-			base.Process(split);
-			projectSyncAction.EndInvoke(projectSyncAction.BeginInvoke(generatedFileNames, null, null));
+			base.Process(split, sync);
+			if (sync)
+				projectSyncAction(generatedFileNames);
 		}
 
 		protected override void CreateFile(String fileName, String content) {
@@ -821,27 +829,26 @@ class Manager {
 
 		internal VSManager(ITextTemplatingEngineHost host, StringBuilder template)
 			: base(host, template) {
-			var hostServiceProvider = (IServiceProvider) host;
+			var hostServiceProvider = (IServiceProvider)host;
 			if (hostServiceProvider == null)
 				throw new ArgumentNullException("Could not obtain IServiceProvider");
 			dte = (EnvDTE.DTE) hostServiceProvider.GetService(typeof(EnvDTE.DTE));
 			if (dte == null)
 				throw new ArgumentNullException("Could not obtain DTE from host");
 			templateProjectItem = dte.Solution.FindProjectItem(host.TemplateFile);
-			checkOutAction = (String fileName) => dte.SourceControl.CheckOutItem(fileName);
-			projectSyncAction = (IEnumerable<String> keepFileNames) => ProjectSync(templateProjectItem, keepFileNames);
+			checkOutAction = fileName => dte.SourceControl.CheckOutItem(fileName);
+			projectSyncAction = keepFileNames => ProjectSync(templateProjectItem, keepFileNames);
 		}
 
-		private static void ProjectSync(EnvDTE.ProjectItem templateProjectItem, IEnumerable<String> keepFileNames) {
+		private static void ProjectSync(EnvDTE.ProjectItem templateProjectItem, List<String> keepFileNames) {
 			var keepFileNameSet = new HashSet<String>(keepFileNames);
 			var projectFiles = new Dictionary<String, EnvDTE.ProjectItem>();
-			var originalFilePrefix = Path.GetFileNameWithoutExtension(templateProjectItem.get_FileNames(0)) + ".";
-            
-			foreach(EnvDTE.ProjectItem projectItem in templateProjectItem.ProjectItems)
-				projectFiles.Add(projectItem.get_FileNames(0), projectItem);
+			var originalFilePrefix = Path.GetFileNameWithoutExtension(templateProjectItem.FileNames[0]) + ".";
+			foreach (EnvDTE.ProjectItem projectItem in templateProjectItem.ProjectItems)
+				projectFiles.Add(projectItem.FileNames[0], projectItem);
 
 			// Remove unused items from the project
-			foreach(var pair in projectFiles)
+			foreach (var pair in projectFiles)
 				if (!keepFileNames.Contains(pair.Key) && !(Path.GetFileNameWithoutExtension(pair.Key) + ".").StartsWith(originalFilePrefix))
 					pair.Value.Delete();
 


### PR DESCRIPTION
- Allows syncing to be turned off
- No longer locks up on VS2017 with .NET Core

There is a chance this will break old versions of VS where the Begin/EndInvoke was required.